### PR TITLE
chore(deps): drop unused multer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "form-data": "^4.0.0",
         "jsonschema": "^1.4.1",
         "lodash": "^4.17.21",
-        "multer": "^2.0.2",
         "secure-compare": "^3.0.1",
         "uuid": "^9.0.1"
       },

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "form-data": "^4.0.0",
     "jsonschema": "^1.4.1",
     "lodash": "^4.17.21",
-    "multer": "^2.0.2",
     "secure-compare": "^3.0.1",
     "uuid": "^9.0.1"
   },


### PR DESCRIPTION
The dependency was specified both as dev dependency and package dependency. However, it is only used in multipart related tests.